### PR TITLE
fix error regarding block comments

### DIFF
--- a/guide/guide.md
+++ b/guide/guide.md
@@ -121,10 +121,10 @@ smaller:
 
 #### Doc comments
 
-Prefer line comments (`///`) to block comments (`//* ... */`).
+Prefer line comments (`///`) to block comments (`/** ... */`).
 
-Prefer outer doc comments (`///` or `//*`), only use inner doc comments (`//!`
-and `//*!`) to write module-level or crate-level documentation.
+Prefer outer doc comments (`///` or `/** ... */`), only use inner doc comments
+(`//!` and `/*! ... */`) to write module-level or crate-level documentation.
 
 Doc comments should come before attributes.
 


### PR DESCRIPTION
The guide makes reference to `//* ... */` comments and `//*!` comments. This appears to have been in error per: https://doc.rust-lang.org/reference/comments.html